### PR TITLE
Update make_patch.py

### DIFF
--- a/make_patch.py
+++ b/make_patch.py
@@ -90,7 +90,7 @@ normalize = transforms.Normalize(mean=netClassifier.mean,
 idx = np.arange(50000)
 np.random.shuffle(idx)
 training_idx = idx[:train_size]
-test_idx = idx[train_size:test_size]
+test_idx = idx[train_size:(train_size + test_size)]
 
 train_loader = torch.utils.data.DataLoader(
     dset.ImageFolder('./imagenetdata/val', transforms.Compose([


### PR DESCRIPTION
Both the `train_size` and `test_size` are same . setting `test_idx = idx[train_size:test_size]` produces an empty list. `test_idx`  has been set to start from `train_size` to `train_size + test_size`